### PR TITLE
Allow duplicate file entries in favorites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,4 +339,6 @@ ASALocalRun/
 # BeatPulse healthcheck temp database
 healthchecksdb
 /.dan
+/.gemini
 /GEMINI.md
+favorites.json

--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,5 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+/.dan
+/GEMINI.md

--- a/SolutionFavorites.slnx
+++ b/SolutionFavorites.slnx
@@ -9,6 +9,7 @@
     <Platform Solution="*|x86" Project="x86" />
   </Project>
   <Project Path="test/SolutionFavorites.Test.csproj">
-    <Build Solution="Debug|*" Project="false" />
+    <Build Solution="Debug|arm64" Project="false" />
+    <Build Solution="Debug|x86" Project="false" />
   </Project>
 </Solution>

--- a/src/FavoritesManager.cs
+++ b/src/FavoritesManager.cs
@@ -21,8 +21,8 @@ namespace SolutionFavorites
         private string _currentSolutionPath;
         private string _solutionDirectory;
         
-        // HashSet for O(1) duplicate file path lookups (stores lowercase relative paths)
-        private HashSet<string> _filePathIndex;
+        // Dictionary for O(1) file path lookups (stores lowercase relative paths and their occurrence count)
+        private Dictionary<string, int> _filePathIndex;
 
         /// <summary>
         /// Gets the singleton instance.
@@ -53,7 +53,7 @@ namespace SolutionFavorites
         private FavoritesManager()
         {
             _data = new FavoritesData();
-            _filePathIndex = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _filePathIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace SolutionFavorites
             _currentSolutionPath = solutionPath;
             _solutionDirectory = Path.GetDirectoryName(solutionPath);
             _data = new FavoritesData();
-            _filePathIndex = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _filePathIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
             var filePath = GetFavoritesFilePath(solutionPath);
             if (filePath != null && File.Exists(filePath))
@@ -224,7 +224,7 @@ namespace SolutionFavorites
             _currentSolutionPath = null;
             _solutionDirectory = null;
             _data = new FavoritesData();
-            _filePathIndex = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _filePathIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             RaiseFavoritesChanged();
         }
 
@@ -322,15 +322,9 @@ namespace SolutionFavorites
 
             var relativePath = ToRelativePath(filePath);
 
-            // Check if file already exists anywhere (O(1) lookup)
-            if (FileExistsInTree(relativePath))
-            {
-                return null;
-            }
-
             var item = FavoriteItem.CreateFile(relativePath);
             InsertSorted(_data.Items, item); // Insert in sorted position
-            _filePathIndex.Add(relativePath); // Maintain index
+            IncrementPathIndex(relativePath); // Maintain index
             
             // Auto-show favorites when adding first item
             if (!_isVisible)
@@ -354,15 +348,9 @@ namespace SolutionFavorites
 
             var relativePath = ToRelativePath(filePath);
 
-            // Check if file already exists anywhere (O(1) lookup)
-            if (FileExistsInTree(relativePath))
-            {
-                return null;
-            }
-
             var item = FavoriteItem.CreateFile(relativePath);
             InsertSorted(folder.Children, item); // Insert in sorted position
-            _filePathIndex.Add(relativePath); // Maintain index
+            IncrementPathIndex(relativePath); // Maintain index
             Save();
             RaiseFavoritesChanged(folder); // Specific folder affected
             return item;
@@ -476,6 +464,45 @@ namespace SolutionFavorites
         }
 
         /// <summary>
+        /// Increments the occurrence count of a path in the index.
+        /// </summary>
+        private void IncrementPathIndex(string relativePath)
+        {
+            if (string.IsNullOrEmpty(relativePath))
+                return;
+
+            if (_filePathIndex.TryGetValue(relativePath, out int count))
+            {
+                _filePathIndex[relativePath] = count + 1;
+            }
+            else
+            {
+                _filePathIndex[relativePath] = 1;
+            }
+        }
+
+        /// <summary>
+        /// Decrements the occurrence count of a path in the index.
+        /// </summary>
+        private void DecrementPathIndex(string relativePath)
+        {
+            if (string.IsNullOrEmpty(relativePath))
+                return;
+
+            if (_filePathIndex.TryGetValue(relativePath, out int count))
+            {
+                if (count <= 1)
+                {
+                    _filePathIndex.Remove(relativePath);
+                }
+                else
+                {
+                    _filePathIndex[relativePath] = count - 1;
+                }
+            }
+        }
+
+        /// <summary>
         /// Removes an item from the tree.
         /// </summary>
         public void Remove(FavoriteItem item)
@@ -487,7 +514,7 @@ namespace SolutionFavorites
             // Remove from path index
             if (!item.IsFolder && !string.IsNullOrEmpty(item.Path))
             {
-                _filePathIndex.Remove(item.Path);
+                DecrementPathIndex(item.Path);
             }
             else if (item.IsFolder)
             {
@@ -523,7 +550,7 @@ namespace SolutionFavorites
         /// </summary>
         private bool FileExistsInTree(string relativePath)
         {
-            return _filePathIndex.Contains(relativePath);
+            return _filePathIndex.ContainsKey(relativePath);
         }
 
         /// <summary>
@@ -544,7 +571,7 @@ namespace SolutionFavorites
             {
                 if (!item.IsFolder && !string.IsNullOrEmpty(item.Path))
                 {
-                    _filePathIndex.Add(item.Path);
+                    IncrementPathIndex(item.Path);
                 }
                 else if (item.IsFolder && item.Children != null)
                 {
@@ -565,7 +592,7 @@ namespace SolutionFavorites
             {
                 if (!item.IsFolder && !string.IsNullOrEmpty(item.Path))
                 {
-                    _filePathIndex.Remove(item.Path);
+                    DecrementPathIndex(item.Path);
                 }
                 else if (item.IsFolder && item.Children != null)
                 {

--- a/src/SolutionFavorites.csproj
+++ b/src/SolutionFavorites.csproj
@@ -121,6 +121,9 @@
     <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.549" ExcludeAssets="Runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework">
+      <Version>17.14.40264</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.14.2120">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/test/FavoritesManager/HasFavoritesTests.cs
+++ b/test/FavoritesManager/HasFavoritesTests.cs
@@ -108,5 +108,27 @@ namespace SolutionFavorites.Test.FavoritesManager
 
             Assert.IsFalse(manager.IsFileFavorited(absolutePath));
         }
+
+        // --- Duplicates ---
+
+        [TestMethod]
+        public void LoadWithDuplicates_IsAllowedAndIndexed()
+        {
+            var solutionPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "Test.sln");
+            Directory.CreateDirectory(Path.GetDirectoryName(solutionPath)!);
+            var favoritesPath = Path.Combine(Path.GetDirectoryName(solutionPath)!, "favorites.json");
+
+            var data = new FavoritesData();
+            data.Items.Add(FavoriteItem.CreateFile(@"src\Program.cs"));
+            data.Items.Add(FavoriteItem.CreateFile(@"src\Program.cs"));
+            File.WriteAllText(favoritesPath, Newtonsoft.Json.JsonConvert.SerializeObject(data));
+
+            var manager = SolutionFavorites.FavoritesManager.CreateForTesting();
+            manager.LoadForSolution(solutionPath);
+
+            var absolutePath = Path.Combine(manager.SolutionDirectory!, @"src\Program.cs");
+            Assert.IsTrue(manager.HasFavorites);
+            Assert.IsTrue(manager.IsFileFavorited(absolutePath));
+        }
     }
 }

--- a/test/FavoritesManager/PersistenceTests.cs
+++ b/test/FavoritesManager/PersistenceTests.cs
@@ -98,6 +98,23 @@ namespace SolutionFavorites.Test.FavoritesManager
         }
 
         [TestMethod]
+        public void LoadForSolution_WithDuplicates_IndexesAllOccurrences()
+        {
+            var solutionPath = CreateSolutionPath();
+            var data = new FavoritesData();
+            data.Items.Add(FavoriteItem.CreateFile(@"src\Program.cs"));
+            data.Items.Add(FavoriteItem.CreateFile(@"src\Program.cs"));
+            WriteFavoritesJson(solutionPath, data);
+
+            var manager = SolutionFavorites.FavoritesManager.CreateForTesting();
+            manager.LoadForSolution(solutionPath);
+
+            var absolutePath = Path.Combine(manager.SolutionDirectory!, @"src\Program.cs");
+            Assert.IsTrue(manager.HasFavorites);
+            Assert.IsTrue(manager.IsFileFavorited(absolutePath));
+        }
+
+        [TestMethod]
         public void LoadForSolution_ValidFile_IsVisibleWhenItemsPresent()
         {
             var solutionPath = CreateSolutionPath();


### PR DESCRIPTION
## What
Allow the same file to be added to favorites multiple times.

## Why
This makes it possible to place the same file into different logical folders or contexts without losing existing favorite entries.

## Changes
- Migrated path indexing to support reference counting.
- Updated duplicate-handling behavior for favorite entries.
- Fixed unit tests to work without UI thread dependencies.

## Testing
- Updated and ran unit tests.
- Verified duplicate favorite entries can coexist.